### PR TITLE
Automatically download kindlegen

### DIFF
--- a/build-clean.sh
+++ b/build-clean.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export KINDLEGEN="`pwd`/build/kindlegen/kindlegen"
-./gradlew all
+./gradlew clean all

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "de.undercouch.download" version "3.4.2"
+}
+
 apply plugin: 'java'
 apply plugin: 'org.asciidoctor.convert'
 apply plugin: 'com.github.ben-manes.versions'
@@ -76,21 +80,12 @@ task mobi(type: AsciidoctorTask, description: 'Generates MOBI') {
     attributes attrs
 }
 
-task downloadKindlegen() {
-  ext.downloadUrl = OperatingSystem.current().isMacOsX() ? 'https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip' : 'http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz'
-  ext.output = file("$buildDir/kindlegen/kindlegen" + (OperatingSystem.current().isMacOsX() ? '.zip' : '.tgz'))
-  outputs.file output
-  inputs.property('downloadUrl', downloadUrl)
-  doLast {
-    if(!output.exists()) {
-      output.parentFile.mkdirs()
-      output.createNewFile()
-    }
-    println "Downloading Kindlegen from $downloadUrl"
-    new URL( downloadUrl ).withInputStream {
-      output << it
-    }
-  }
+task downloadKindlegen(type: Download) {
+    ext.output = file("$buildDir/kindlegen/kindlegen" + (OperatingSystem.current().isMacOsX() ? '.zip' : '.tgz'))
+    src OperatingSystem.current().isMacOsX() ? 'https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip' : 'http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz'
+    dest output
+    overwrite false
+    onlyIfModified true
 }
 
 task extractKindlegen(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ asciidoctorj {
 }
 
 import org.asciidoctor.gradle.AsciidoctorTask
+import org.gradle.internal.os.OperatingSystem
 
 def attrs = ['sourcedir'         : '../../../main/webapp',
              'source-highlighter': 'coderay',
@@ -75,6 +76,37 @@ task mobi(type: AsciidoctorTask, description: 'Generates MOBI') {
     attributes attrs
 }
 
+task downloadKindlegen() {
+  ext.downloadUrl = OperatingSystem.current().isMacOsX() ? 'https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip' : 'http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz'
+  ext.output = file("$buildDir/kindlegen/kindlegen" + (OperatingSystem.current().isMacOsX() ? '.zip' : '.tgz'))
+  outputs.file output
+  inputs.property('downloadUrl', downloadUrl)
+  doLast {
+    if(!output.exists()) {
+      output.parentFile.mkdirs()
+      output.createNewFile()
+    }
+    println "Downloading Kindlegen from $downloadUrl"
+    new URL( downloadUrl ).withInputStream {
+      output << it
+    }
+  }
+}
+
+task extractKindlegen(type: Copy) {
+  dependsOn downloadKindlegen
+  from {
+    if (downloadKindlegen.output.name.endsWith('.zip')) {
+      zipTree(downloadKindlegen.output)
+    }
+    else {
+      tarTree(downloadKindlegen.output)
+    }
+  }
+  into "$buildDir/kindlegen/"
+}
+
+mobi.dependsOn extractKindlegen
 pdf.shouldRunAfter html
 epub.shouldRunAfter pdf
 

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-KINDLEGEN=/opt/tools/kindlegen/kindlegen ./gradlew clean all --stacktrace
+export KINDLEGEN="`pwd`/build/kindlegen/kindlegen"
+./gradlew clean all --stacktrace


### PR DESCRIPTION
I added the example from https://github.com/rwinch/asciidoctor-gradle-examples/blob/kf8/asciidoc-to-epub3-kf8-example/build.gradle and added it here. I also updated `build.sh` to set the environment variable to where it will be downloaded.

This fixes issue #1