### PR TITLE
remove unused Ascii85 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'coderay'
-gem 'Ascii85'
 gem 'asciidoctor-pdf', github: 'asciidoctor/asciidoctor-pdf', ref: '251decae7e6166511f847ce3681e4827a1df0cc6'
 gem 'hexapdf'


### PR DESCRIPTION
...until we know why it's actually here. I don't see any reference to it, and can't think of why it would be needed.