### PR TITLE
resolves #22 switch from CodeRay to Rouge for syntax highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'coderay'
-gem 'asciidoctor-pdf', github: 'asciidoctor/asciidoctor-pdf', ref: '251decae7e6166511f847ce3681e4827a1df0cc6'
+gem 'rouge'
+gem 'asciidoctor-pdf'
 gem 'hexapdf'

--- a/build.gradle
+++ b/build.gradle
@@ -6,15 +6,15 @@ buildscript {
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
         classpath 'com.bluepapa32:gradle-watch-plugin:0.1.5'
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
-        classpath 'org.asciidoctor:asciidoctorj-epub3:1.5.0-alpha.7'
-        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
-        classpath 'org.jruby:jruby-complete:9.1.12.0'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.6.1'
+        classpath 'org.asciidoctor:asciidoctorj-epub3:1.5.0-alpha.9'
+        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-beta.5'
+        classpath 'org.jruby:jruby-complete:9.2.8.0'
     }
 }
 
 plugins {
-    id "de.undercouch.download" version "3.4.2"
+    id 'de.undercouch.download' version '3.4.2'
 }
 
 apply plugin: 'java'
@@ -25,14 +25,14 @@ apply plugin: 'com.bluepapa32.watch'
 version = '4.1.0-SNAPSHOT'
 
 asciidoctorj {
-    version = '1.5.7'
+    version = '2.1.0'
 }
 
 import org.asciidoctor.gradle.AsciidoctorTask
 import org.gradle.internal.os.OperatingSystem
 
 def attrs = ['sourcedir'         : '../../../main/webapp',
-             'source-highlighter': 'coderay',
+             'source-highlighter': 'rouge',
              'epub3-stylesdir'   : './styles/epub',
              // NOTE don't include leading ./ because it messes up paths in the epub files
              'imagesdir'         : 'images',
@@ -65,7 +65,7 @@ task prepress(type: AsciidoctorTask, description: 'Generates PDF for prepress pr
 
 // NOTE please use ./generate-pdf.sh screen instead of this task for now
 task pdf(type: AsciidoctorTask, description: 'Generates PDF') {
-    attributes attrs + ['pdfmarks': '']
+    attributes attrs + ['pdfmarks': '', 'source-highlighter': 'rouge']
     requires file('src/main/ruby/asciidoctor-pdf-extensions.rb')
     backends 'pdf'
 }

--- a/generate-pdf.sh
+++ b/generate-pdf.sh
@@ -24,7 +24,7 @@ MEDIA=prepress
 HIGHLIGHTING=""
 if [ ! -z "$1" ]; then
   MEDIA=$1
-  HIGHLIGHTING="-a source-highlighter=coderay"
+  HIGHLIGHTING="-a source-highlighter=rouge"
 fi
 BASE_DIR="$ROOT_DIR/src/docs/asciidoc"
 OUT_DIR="$ROOT_DIR/build/asciidoc/pdf-$MEDIA"

--- a/src/main/ruby/asciidoctor-pdf-extensions.rb
+++ b/src/main/ruby/asciidoctor-pdf-extensions.rb
@@ -3,7 +3,7 @@ require 'asciidoctor-pdf' unless defined? ::Asciidoctor::Pdf
 module AsciidoctorPdfExtensions
   # Override the built-in layout_toc to move colophon before front of table of contents
   # NOTE we assume that the colophon fits on a single page
-  def layout_toc doc, num_levels = 2, toc_page_number = 2, num_front_matter_pages = 0
+  def layout_toc doc, num_levels = 2, toc_page_number = 2, start_y = nil, num_front_matter_pages = 0
     go_to_page toc_page_number unless (page_number == toc_page_number) || scratch?
     if scratch?
       colophon = doc.find_by(context: :section) {|sect| sect.sectname == 'colophon' }
@@ -20,7 +20,7 @@ module AsciidoctorPdfExtensions
       end
     end
     offset = colophon && !@ppbook ? 1 : 0
-    toc_page_numbers = super doc, num_levels, (toc_page_number + offset), num_front_matter_pages
+    toc_page_numbers = super doc, num_levels, (toc_page_number + offset), start_y, num_front_matter_pages
     scratch? ? ((toc_page_numbers.begin - offset)..toc_page_numbers.end) : toc_page_numbers
   end
 


### PR DESCRIPTION
- upgrade to AsciidoctorJ 2.1.0
- upgrade to AsciidoctorJ PDF 1.5.0-beta.5
- upgrade to AsciidoctorJ EPUB3 1.5.0-beta.9
- upgrade Gradle plugin to 1.6.1
- remove coderay from Gemfile for Ruby-based PDF build
- add rouge to Gemfile for Ruby-based PDF build
- install asciidoctor-pdf gem from rubygems.org for Ruby-based PDF build
- tweak arguments in Asciidoctor PDF extensions to be compatible with Asciidoctor PDF 1.5.0.beta.5