### PR TITLE
Resolve #29 using solution to GitHub issue asciidoctor/asciidoctor-epub3#178

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
         classpath 'com.bluepapa32:gradle-watch-plugin:0.1.5'
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.6.1'
-        classpath 'org.asciidoctor:asciidoctorj-epub3:1.5.0-alpha.9'
+        classpath 'org.asciidoctor:asciidoctorj-epub3:1.5.0-alpha.14'
         classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-beta.5'
         classpath 'org.jruby:jruby-complete:9.2.8.0'
     }
@@ -40,7 +40,8 @@ def attrs = ['sourcedir'         : '../../../main/webapp',
              'icons'             : 'font',
              'sectanchors'       : '',
              'idprefix'          : '',
-             'idseparator'       : '-']
+             'idseparator'       : '-',
+             'listing-caption'   : 'Listing']
 
 tasks.withType(AsciidoctorTask) { task ->
     attributes attrs


### PR DESCRIPTION
This pull request resolves #29 by updating the epub dependency from alpha.9 to alpha.14 and setting the listing-caption which is suppressed.

[A commit in the "Upgrade dependencies to latest versions" branch](https://github.com/mraible/infoq-mini-book/commit/817fb5e5428a6ad19f01858c4971e8a34b9786ba) updates the dependency to alpha.16, so will supersede that part of this change if merged.  This also works and will not reinstate this issue but is insufficient without the listing-caption change.