### PR TITLE
modernize Asciidoctor PDF usage

### DIFF
--- a/src/docs/asciidoc/modules/ROOT/index.adoc
+++ b/src/docs/asciidoc/modules/ROOT/index.adoc
@@ -19,9 +19,9 @@ endif::[]
 :lang: en
 :language: javadocript
 :experimental:
-:pdf-fontsdir: ./styles/pdf/fonts
-:pdf-stylesdir: ./styles/pdf
-:pdf-style: screen
+:pdf-fontsdir: {docdir}/styles/pdf/fonts
+:pdf-themesdir: {docdir}/styles/pdf
+:pdf-theme: screen
 ifndef::ebook-format[:leveloffset: 1]
 
 [colophon#colophon%nonfacing]

--- a/src/main/ruby/asciidoctor-pdf-extensions.rb
+++ b/src/main/ruby/asciidoctor-pdf-extensions.rb
@@ -1,6 +1,8 @@
-require 'asciidoctor-pdf' unless defined? ::Asciidoctor::Pdf
+require 'asciidoctor-pdf' unless Asciidoctor::Converter.for 'pdf'
 
-module AsciidoctorPdfExtensions
+class AsciidoctorPDFExtensions < (Asciidoctor::Converter.for 'pdf')
+  register_for 'pdf'
+
   # Override the built-in layout_toc to move colophon before front of table of contents
   # NOTE we assume that the colophon fits on a single page
   def layout_toc doc, num_levels = 2, toc_page_number = 2, start_y = nil, num_front_matter_pages = 0
@@ -121,5 +123,3 @@ module AsciidoctorPdfExtensions
     move_down 20
   end
 end
-
-Asciidoctor::Pdf::Converter.prepend AsciidoctorPdfExtensions


### PR DESCRIPTION
* switch from pdf-style/pdf-stylesdir to pdf-theme/pdf-themesdir
* register PDF extensions using extended converter

These changes will help you prepare for the Asciidoctor PDF 2 release, yet they work with Asciidoctor PDF 1.5.x and 1.6.x as well.